### PR TITLE
Fix USDT balance lookup and add test

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 import time
-import random
 from strategy import should_buy, should_sell
 from utils.binance_api import client
 from dotenv import load_dotenv
@@ -23,8 +22,8 @@ STOP_LOSS = 0.08
 open_positions = {}
 
 def get_balance_usdt():
-    balance = client.get_asset_balance(asset='UST')
-    return float(balance['free'])
+    balance = client.get_asset_balance(asset="USDT")
+    return float(balance["free"])
 
 def place_order(symbol, side, quantity):
     print(f"[ORDER] {side} {symbol} x {quantity}")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,38 @@
+import types
+import sys
+from pathlib import Path
+
+# Ensure project root on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+# Stub out binance client to avoid network calls during import
+class _ClientStub:
+    def __init__(self, *args, **kwargs):
+        pass
+    def get_asset_balance(self, asset):
+        return {"free": "0"}
+
+client_module = types.ModuleType("client")
+client_module.Client = _ClientStub
+binance_module = types.ModuleType("binance")
+binance_module.client = client_module
+sys.modules.setdefault("binance", binance_module)
+sys.modules.setdefault("binance.client", client_module)
+
+import main
+
+class DummyClient:
+    def __init__(self):
+        self.asset = None
+    def get_asset_balance(self, asset):
+        self.asset = asset
+        return {"free": "100"}
+
+
+def test_get_balance_usdt(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(main, "client", dummy)
+    balance = main.get_balance_usdt()
+    assert balance == 100.0
+    assert dummy.asset == "USDT"


### PR DESCRIPTION
## Summary
- correct Binance balance query to request USDT instead of UST
- add unit test for USDT balance retrieval

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895aa2be5ac8320a18d83f74003cc2f