### PR TITLE
feat(gui): include dashboard and strategy routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Binance RSI Bot
 
 To deploy: click Railway button or use CLI
+
+## API
+
+The application exposes REST endpoints documented at `/docs`:
+
+- `GET /api/data/{symbol}` – retrieve market data for the specified trading pair.
+- `GET /api/strategy` – fetch the current trading strategy.
+- `POST /api/strategy` – update the trading strategy.

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,4 @@
+from .main import app
+
+__all__ = ["app"]
+

--- a/gui/main.py
+++ b/gui/main.py
@@ -4,7 +4,13 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 import os
 
+from .dashboard import router as dashboard_router
+from .strategy_editor import router as strategy_router
+
 app = FastAPI()
+
+app.include_router(dashboard_router, prefix="/api")
+app.include_router(strategy_router, prefix="/api")
 
 app.mount("/static", StaticFiles(directory="gui/static"), name="static")
 templates = Jinja2Templates(directory="gui/templates")


### PR DESCRIPTION
## Summary
- register dashboard and strategy editor APIs in FastAPI app
- export app via gui package initializer

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895d42998e08320b49e89440aa2faf8