### PR TITLE
feat(gui): add trading pair fallback and state storage

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: sh -c "python main.py & uvicorn gui.main:app --host 0.0.0.0 --port $PORT"
+# ensure combined bot and API run in one process

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn gui.main:app --host 0.0.0.0 --port $PORT
+web: sh -c "python main.py & uvicorn gui.main:app --host 0.0.0.0 --port $PORT"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # Binance RSI Bot
 
 To deploy: click Railway button or use CLI
+
+## API
+
+The application exposes REST endpoints documented at `/docs`:
+
+- `GET /api/data/{symbol}` – retrieve market data for the specified trading pair.
+- `GET /api/trading_pairs` – list trading pairs used by the bot, fetching from Binance CMS if the state file is empty.
+- `GET /api/strategy` – fetch the current trading strategy.
+- `POST /api/strategy` – update the trading strategy.
+- `GET /api/debug/pairs` – debug helper showing the trading pairs state.

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,4 @@
+from .main import app
+
+__all__ = ["app"]
+

--- a/gui/dashboard.py
+++ b/gui/dashboard.py
@@ -1,8 +1,37 @@
 from fastapi import APIRouter
 from utils.indicators import calculate_rsi, calculate_ema
 from utils.binance_api import get_price_data
+from utils.state import get_trading_pairs, set_trading_pairs
+from utils.new_listings import get_newlisting_usdt_pairs
 
 router = APIRouter()
+
+@router.get("/debug/pairs")
+def debug_pairs():
+    from utils.state import TRADING_PAIRS_FILE, DATA_DIR
+    pairs = get_trading_pairs()
+    return {
+        "count": len(pairs),
+        "pairs": pairs,
+        "data_dir": str(DATA_DIR),
+        "file_exists": (TRADING_PAIRS_FILE.exists()),
+    }
+
+@router.get("/trading_pairs")
+def trading_pairs():
+    """
+    Palauttaa botin käyttämät parit. Jos state on tyhjä (botti ei kirjoittanut vielä),
+    hae suoraan Binancen CMS:stä ja tallenna stateen.
+    """
+    pairs = get_trading_pairs() or []
+    if not pairs:
+        try:
+            pairs = get_newlisting_usdt_pairs(limit=30) or []
+        except Exception:
+            pairs = []
+        if pairs:
+            set_trading_pairs(pairs)
+    return {"pairs": pairs}
 
 @router.get("/data/{symbol}")
 def get_indicator_data(symbol: str):

--- a/gui/main.py
+++ b/gui/main.py
@@ -4,7 +4,13 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 import os
 
+from .dashboard import router as dashboard_router
+from .strategy_editor import router as strategy_router
+
 app = FastAPI()
+
+app.include_router(dashboard_router, prefix="/api")
+app.include_router(strategy_router, prefix="/api")
 
 app.mount("/static", StaticFiles(directory="gui/static"), name="static")
 templates = Jinja2Templates(directory="gui/templates")

--- a/main.py
+++ b/main.py
@@ -2,18 +2,21 @@ import time
 from strategy import should_buy, should_sell
 from utils.binance_api import client
 from dotenv import load_dotenv
-import os
+from utils.state import get_trading_pairs, set_trading_pairs
+from utils.new_listings import get_newlisting_usdt_pairs
 
 load_dotenv()
 
-TRADE_SYMBOLS = [
-    "BTCUSDT", "ETHUSDT", "BNBUSDT", "XRPUSDT", "SOLUSDT",
-    "ADAUSDT", "DOGEUSDT", "AVAXUSDT", "DOTUSDT", "LINKUSDT",
-    "MATICUSDT", "TRXUSDT", "LTCUSDT", "SHIBUSDT", "UNIUSDT",
-    "BCHUSDT", "ATOMUSDT", "XLMUSDT", "NEARUSDT", "FILUSDT",
-    "ETCUSDT", "ICPUSDT", "HBARUSDT", "VETUSDT", "SANDUSDT",
-    "EGLDUSDT", "GRTUSDT", "AAVEUSDT", "MKRUSDT", "FTMUSDT"
-]
+TRADE_SYMBOLS = get_trading_pairs() or []
+if not TRADE_SYMBOLS:
+    try:
+        TRADE_SYMBOLS = get_newlisting_usdt_pairs(limit=30) or []
+    except Exception:
+        TRADE_SYMBOLS = []
+    if TRADE_SYMBOLS:
+        set_trading_pairs(TRADE_SYMBOLS)
+
+print(f"Using TRADE_SYMBOLS (newListing): {TRADE_SYMBOLS}")
 
 USED_USD_PERCENTAGE = 0.1
 TAKE_PROFIT = 0.05
@@ -21,13 +24,16 @@ STOP_LOSS = 0.08
 
 open_positions = {}
 
+
 def get_balance_usdt():
     balance = client.get_asset_balance(asset="USDT")
     return float(balance["free"])
 
+
 def place_order(symbol, side, quantity):
     print(f"[ORDER] {side} {symbol} x {quantity}")
     # client.create_order(...)
+
 
 def check_positions():
     for symbol in list(open_positions):
@@ -45,6 +51,7 @@ def check_positions():
             print(f"[SL HIT] Selling {symbol} with {pnl*100:.2f}%")
             place_order(symbol, "SELL", quantity)
             del open_positions[symbol]
+
 
 def run_bot():
     while True:
@@ -66,6 +73,7 @@ def run_bot():
                 print(f"[Signal] {symbol}: Sell signal detected.")
 
         time.sleep(60 * 5)
+
 
 if __name__ == "__main__":
     print("🔁 Bot is starting...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-binance
 pandas
 numpy
 python-multipart
+requests

--- a/utils/new_listings.py
+++ b/utils/new_listings.py
@@ -1,0 +1,54 @@
+# utils/new_listings.py
+import re
+import requests
+from typing import List
+from utils.binance_api import client
+
+CMS_URLS = [
+    "https://www.binance.com/bapi/composite/v1/public/cms/article/list?pageSize=100&pageNo=1&categoryCode=listing",
+    "https://www.binance.com/bapi/composite/v1/public/cms/article/list?pageSize=100&pageNo=1&categoryCode=new_crypto_listing",
+]
+SYMBOL_RE = re.compile(r"\(([A-Z0-9]{2,15})\)")
+
+
+def _fetch_listing_titles() -> List[str]:
+    for url in CMS_URLS:
+        r = requests.get(url, timeout=10)
+        if r.ok:
+            data = r.json()
+            items = (data.get("data") or {}).get("articles") or []
+            titles = [it.get("title") for it in items if it]
+            if titles:
+                return titles
+    return []
+
+
+def _extract_tickers(titles: List[str]) -> List[str]:
+    out, seen = [], set()
+    for t in titles:
+        m = SYMBOL_RE.search(t or "")
+        if m:
+            tk = m.group(1)
+            if tk not in seen:
+                seen.add(tk)
+                out.append(tk)
+    return out
+
+
+def _filter_usdt_spot(tickers: List[str]) -> List[str]:
+    info = client.get_exchange_info()
+    meta = {s["symbol"]: s for s in info.get("symbols", [])}
+    out = []
+    for tk in tickers:
+        pair = f"{tk}USDT"
+        s = meta.get(pair)
+        if s and s.get("status") == "TRADING" and s.get("isSpotTradingAllowed", True):
+            out.append(pair)
+    return out
+
+
+def get_newlisting_usdt_pairs(limit: int = 30) -> List[str]:
+    titles = _fetch_listing_titles()
+    tickers = _extract_tickers(titles)
+    pairs = _filter_usdt_spot(tickers)
+    return pairs[:limit]

--- a/utils/state.py
+++ b/utils/state.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import json
+from typing import List
+
+# Determine absolute data directory relative to this file
+DATA_DIR = (Path(__file__).resolve().parent.parent / "data").resolve()
+TRADING_PAIRS_FILE = DATA_DIR / "trading_pairs.json"
+
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def get_trading_pairs() -> List[str]:
+    if TRADING_PAIRS_FILE.exists():
+        try:
+            return json.loads(TRADING_PAIRS_FILE.read_text())
+        except Exception:
+            return []
+    return []
+
+
+def set_trading_pairs(pairs: List[str]) -> None:
+    TRADING_PAIRS_FILE.write_text(json.dumps(pairs))


### PR DESCRIPTION
## Summary
- persist trading pair state under an absolute `data` directory and fetch from Binance CMS when empty
- expose `/api/trading_pairs` and `/api/debug/pairs` endpoints with automatic fallback to new listings
- initialize bot symbols from stored or CMS-fetched pairs and run bot and API together in the Procfile

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `curl -i https://binancehelper-production.up.railway.app/api/trading_pairs` (HTTP 403)
- `curl -i https://binancehelper-production.up.railway.app/api/debug/pairs` (HTTP 403)
- `curl -i https://binancehelper-production.up.railway.app/dashboard` (HTTP 403)
- `git push` (no configured push destination)


------
https://chatgpt.com/codex/tasks/task_e_6895d42998e08320b49e89440aa2faf8